### PR TITLE
Set expo public api base url

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE=http://localhost:3000


### PR DESCRIPTION
Add `EXPO_PUBLIC_API_BASE` to a new `.env` file to set the environment variable as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-cadfa174-36bf-41d5-aa7d-f40fd5f1eb92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cadfa174-36bf-41d5-aa7d-f40fd5f1eb92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

