### PR TITLE
Setup and run expo preview build

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,8 +8,8 @@
 		"updates": { "fallbackToCacheTimeout": 0 },
 		"runtimeVersion": { "policy": "sdkVersion" },
 		"assetBundlePatterns": ["**/*"],
-		"ios": { "supportsTablet": true },
-		"android": {},
+		"ios": { "supportsTablet": true, "bundleIdentifier": "com.novax.ello" },
+		"android": { "package": "com.novax.ello" },
 		"web": { "bundler": "metro" }
 	}
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mobile",
+  "name": "@novax/mobile",
   "version": "0.1.0",
   "private": true,
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:web": "turbo run dev --filter=web",
-    "dev:mobile": "turbo run dev --filter=mobile",
+    "dev:mobile": "turbo run dev --filter=@novax/mobile",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
Configure `apps/mobile` for EAS builds and set its package name to `@novax/mobile` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-58213aea-208f-4fa1-955e-5b9390b9c31f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58213aea-208f-4fa1-955e-5b9390b9c31f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

