### PR TITLE
Update preview build and provide Expo Go link

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,15 +1,31 @@
 {
-	"expo": {
-		"name": "Ello",
-		"slug": "ello-replica",
-		"scheme": "ello",
-		"version": "0.1.0",
-		"orientation": "portrait",
-		"updates": { "fallbackToCacheTimeout": 0 },
-		"runtimeVersion": { "policy": "sdkVersion" },
-		"assetBundlePatterns": ["**/*"],
-		"ios": { "supportsTablet": true },
-		"android": {},
-		"web": { "bundler": "metro" }
-	}
+  "expo": {
+    "name": "Ello",
+    "slug": "ello-replica",
+    "scheme": "ello",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "updates": {
+      "fallbackToCacheTimeout": 0,
+      "url": "https://u.expo.dev/8bf47054-2f13-4ed8-9791-2dda71064779"
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {},
+    "web": {
+      "bundler": "metro"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "8bf47054-2f13-4ed8-9791-2dda71064779"
+      }
+    }
+  }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,7 +18,8 @@
     "expo-linear-gradient": "~13.0.2",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
-    "react-native": "0.74.3"
+    "react-native": "0.74.3",
+    "expo-updates": "~0.25.28"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-haptics": "~13.0.1",
         "expo-linear-gradient": "~13.0.2",
         "expo-status-bar": "~1.12.1",
+        "expo-updates": "~0.25.28",
         "react": "18.2.0",
         "react-native": "0.74.3"
       },
@@ -3173,6 +3174,37 @@
         "dotenv": "~16.4.5",
         "dotenv-expand": "~11.0.6",
         "getenv": "^1.0.0"
+      }
+    },
+    "node_modules/@expo/fingerprint": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.10.3.tgz",
+      "integrity": "sha512-h/BnnyloJyMSrzeXonKLE6HfiMpRg3e9m8CAv+eUaAozG9heKMG9ftHW4cfm2StDYj/rWjFc5YK6MSIX6qd+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "find-up": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^3.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "bin": {
+        "fingerprint": "bin/cli.js"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@expo/image-utils": {
@@ -13032,6 +13064,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.12.0.tgz",
+      "integrity": "sha512-Jkww9Cwpv0z7DdLYiRX0r4fqBEcI9cKqTn7cHx63S09JaZ2rcwEE4zYHgrXwjahO+tU2VW8zqH+AJl6RhhW4zA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-17.0.1.tgz",
@@ -13062,6 +13100,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.13.1.tgz",
+      "integrity": "sha512-mlfaSArGVb+oJmUcR22jEONlgPp0wj4iNIHfQ2je9Q8WTOqMc0Ws9tUciz3JdJnhffdHqo/k8fpvf0IRmN5HPA==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz",
@@ -13076,6 +13120,19 @@
       "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-13.0.2.tgz",
       "integrity": "sha512-EDcILUjRKu4P1rtWcwciN6CSyGtH7Bq4ll3oTRV7h3h8oSzSilH1g6z7kTAMlacPBKvMnkkWOGzW6KtgMKEiTg==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.14.3.tgz",
+      "integrity": "sha512-L3b5/qocBPiQjbW0cpOHfnqdKZbTJS7sA3mgeDJT+mWga/xYsdpma1EfNmsuvrOzjLGjStr1k1fceM9Bl49aqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~9.0.0",
+        "expo-json-utils": "~0.13.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -13147,6 +13204,56 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.12.1.tgz",
       "integrity": "sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-3.8.0.tgz",
+      "integrity": "sha512-R+gFGn0x5CWl4OVlk2j1bJTJIz4KO8mPoCHpRHmfqMjmrMvrOM0qQSY3V5NHXwp1yT/L2v8aUmFQsBRIdvi1XA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "0.25.28",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.25.28.tgz",
+      "integrity": "sha512-NTI1r7wvXel36qCzKwCjCJ9HExBo6GX9wkA9WzaNsysmg+eEd5BCmcaxvQGZUQkfDocEfI78N5vRBSuMi0iS1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~9.0.0-beta.0",
+        "@expo/config-plugins": "~8.0.8",
+        "@expo/fingerprint": "^0.10.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.12.0",
+        "expo-manifests": "~0.14.0",
+        "expo-structured-headers": "~3.8.0",
+        "expo-updates-interface": "~0.16.2",
+        "fast-glob": "^3.3.2",
+        "fbemitter": "^3.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.16.2.tgz",
+      "integrity": "sha512-929XBU70q5ELxkKADj1xL0UIm3HvhYhNAOZv5DSk7rrKvLo7QDdPyl+JVnwZm9LrkNbH4wuE2rLoKu1KMgZ+9A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
       "license": "MIT"
     },
     "node_modules/exponential-backoff": {


### PR DESCRIPTION
Link the Expo project to EAS and install `expo-updates` to enable EAS update functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba56b245-140d-496e-9c86-13e444e444fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba56b245-140d-496e-9c86-13e444e444fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

